### PR TITLE
Remove redundant handler function

### DIFF
--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -27,7 +27,6 @@ func Start() {
 	}
 
 	apiMux := http.NewServeMux()
-	apiMux.HandleFunc("/api/records", handlers.Records)
 	apiMux.HandleFunc("/api/records/", handlers.Records)
 
 	http.Handle("/api/", middlewares.LogRequest(apiMux))


### PR DESCRIPTION
Pattern `/records/` handles everything (`/records`, `/records/` and `/records/something`).
Pattern `/records` handles just `/records`.

https://pkg.go.dev/net/http#example-ServeMux.Handle